### PR TITLE
Simplified CommandShowAccess

### DIFF
--- a/src/ca/glasspelican/worldhistory/commands/CommandShowAccess.java
+++ b/src/ca/glasspelican/worldhistory/commands/CommandShowAccess.java
@@ -2,6 +2,7 @@ package ca.glasspelican.worldhistory.commands;
 
 import ca.glasspelican.worldhistory.WorldHistory;
 import ca.glasspelican.worldhistory.lib.config.Config;
+
 import net.minecraft.command.CommandBase;
 import net.minecraft.command.CommandException;
 import net.minecraft.command.ICommand;

--- a/src/ca/glasspelican/worldhistory/commands/CommandShowAccess.java
+++ b/src/ca/glasspelican/worldhistory/commands/CommandShowAccess.java
@@ -2,6 +2,7 @@ package ca.glasspelican.worldhistory.commands;
 
 import ca.glasspelican.worldhistory.WorldHistory;
 import ca.glasspelican.worldhistory.lib.config.Config;
+import net.minecraft.command.CommandBase;
 import net.minecraft.command.CommandException;
 import net.minecraft.command.ICommand;
 import net.minecraft.command.ICommandSender;
@@ -14,7 +15,7 @@ import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 
-public class CommandShowAccess implements ICommand {
+public class CommandShowAccess extends CommandBase {
 
     private List<String> aliases;
 
@@ -67,67 +68,5 @@ public class CommandShowAccess implements ICommand {
     @Override
     public boolean checkPermission(MinecraftServer server, ICommandSender sender) {
         return !(sender instanceof EntityPlayerMP) || Config.isUserAMod(((EntityPlayerMP) sender).getName());
-    }
-
-    /**
-     * Get a list of options for when the user presses the TAB key
-     *
-     * @param server
-     * @param sender
-     * @param args
-     * @param pos
-     */
-    @Override
-    public List<String> getTabCompletionOptions(MinecraftServer server, ICommandSender sender, String[] args, @Nullable BlockPos pos) {
-        return null;
-    }
-
-    @Override
-    public boolean isUsernameIndex(String[] p_82358_1_, int p_82358_2_) {
-
-        return false;
-    }
-
-    /**
-     * Compares this object with the specified object for order.  Returns a
-     * negative integer, zero, or a positive integer as this object is less
-     * than, equal to, or greater than the specified object.
-     * <p>
-     * <p>The implementor must ensure <tt>sgn(x.compareTo(y)) ==
-     * -sgn(y.compareTo(x))</tt> for all <tt>x</tt> and <tt>y</tt>.  (This
-     * implies that <tt>x.compareTo(y)</tt> must throw an exception iff
-     * <tt>y.compareTo(x)</tt> throws an exception.)
-     * <p>
-     * <p>The implementor must also ensure that the relation is transitive:
-     * <tt>(x.compareTo(y)&gt;0 &amp;&amp; y.compareTo(z)&gt;0)</tt> implies
-     * <tt>x.compareTo(z)&gt;0</tt>.
-     * <p>
-     * <p>Finally, the implementor must ensure that <tt>x.compareTo(y)==0</tt>
-     * implies that <tt>sgn(x.compareTo(z)) == sgn(y.compareTo(z))</tt>, for
-     * all <tt>z</tt>.
-     * <p>
-     * <p>It is strongly recommended, but <i>not</i> strictly required that
-     * <tt>(x.compareTo(y)==0) == (x.equals(y))</tt>.  Generally speaking, any
-     * class that implements the <tt>Comparable</tt> interface and violates
-     * this condition should clearly indicate this fact.  The recommended
-     * language is "Note: this class has a natural ordering that is
-     * inconsistent with equals."
-     * <p>
-     * <p>In the foregoing description, the notation
-     * <tt>sgn(</tt><i>expression</i><tt>)</tt> designates the mathematical
-     * <i>signum</i> function, which is defined to return one of <tt>-1</tt>,
-     * <tt>0</tt>, or <tt>1</tt> according to whether the value of
-     * <i>expression</i> is negative, zero or positive.
-     *
-     * @param o the object to be compared.
-     * @return a negative integer, zero, or a positive integer as this object
-     * is less than, equal to, or greater than the specified object.
-     * @throws NullPointerException if the specified object is null
-     * @throws ClassCastException   if the specified object's type prevents it
-     *                              from being compared to this object.
-     */
-    @Override
-    public int compareTo(ICommand o) {
-        return 0;
     }
 }


### PR DESCRIPTION
This also prevents spam that results from thrown NPEs when pressing tab (as of 1.9 this happens when getTabCompletionOptions returns null).